### PR TITLE
Change `qstring.nest` to use `dict` in the returned nested object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Added support for Python 3.8, 3.9, 3.10 and 3.11.
 - Dropped support for Python 2.7, 3.3, 3.4, 3.5, 3.6 and 3.7.
+- Changed ``qstring.nest`` to use ``dict`` in the returned nested object instead
+  of ``OrderedDict``. ``dict`` retains insertion order since Python 3.7, so
+  ``OrderedDict`` usage was redundant here.
 
 0.2.1 (March 24, 2017)
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/qstring/nest.py
+++ b/qstring/nest.py
@@ -23,7 +23,7 @@ def nest(params):
     :raises qstring.ParameterTypeError:
         if parameters of conflicting types are given.
     """
-    nested = collections.OrderedDict()
+    nested = {}
     params = _convert_params_list_to_dict(params)
     for key, value in params.items():
         try:
@@ -35,7 +35,7 @@ def nest(params):
 
 
 def _convert_params_list_to_dict(params_list):
-    params_dict = collections.OrderedDict()
+    params_dict = {}
     for key, value in params_list:
         if key in params_dict:
             params_dict[key] = [params_dict[key], value]
@@ -54,7 +54,7 @@ class _ParameterParser:
         self.value = value
         self.tokens = list(self._tokenize(key))
         key = self._match_name()
-        return collections.OrderedDict([(key, self._parse_object())])
+        return {key: self._parse_object()}
 
     def _tokenize(self, input):
         for value in re.split(r'([\[\]])', input):
@@ -69,7 +69,7 @@ class _ParameterParser:
         if not self.tokens:
             return self.value
         key = self._match_object()
-        return collections.OrderedDict([(key, self._parse_object())])
+        return {key: self._parse_object()}
 
     def _match_name(self):
         token, = self._match('NAME')

--- a/tests/test_unnest.py
+++ b/tests/test_unnest.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import pytest
 
 import qstring
@@ -9,47 +7,43 @@ import qstring
     ('obj', 'expected'),
     [
         (
-            OrderedDict([('', '')]),
+            {'': ''},
             [('', '')]
         ),
         (
-            OrderedDict([('foo', '')]),
+            {'foo': ''},
             [('foo', '')]
         ),
         (
-            OrderedDict([('', 'bar')]),
+            {'': 'bar'},
             [('', 'bar')]
         ),
         (
-            OrderedDict([('foo', 'bar')]),
+            {'foo': 'bar'},
             [('foo', 'bar')]
         ),
         (
-            OrderedDict([('foo', 'äö')]),
+            {'foo': 'äö'},
             [('foo', 'äö')]
         ),
         (
-            OrderedDict([('foo', ''), ('bar', '')]),
+            {'foo': '', 'bar': ''},
             [('foo', ''), ('bar', '')]
         ),
         (
-            OrderedDict([('foo', ['1', '2'])]),
+            {'foo': ['1', '2']},
             [('foo', '1'), ('foo', '2')]
         ),
         (
-            OrderedDict([('foo', '1'), ('bar', '2')]),
+            {'foo': '1', 'bar': '2'},
             [('foo', '1'), ('bar', '2')]
         ),
         (
-            OrderedDict([('x', OrderedDict([('y', '1')]))]),
+            {'x': {'y': '1'}},
             [('x[y]', '1')]
         ),
         (
-            OrderedDict([
-                ('x', OrderedDict([
-                    ('y', OrderedDict([('z', '1')]))
-                ]))
-            ]),
+            {'x': {'y': {'z': '1'}}},
             [('x[y][z]', '1')]
         ),
     ]


### PR DESCRIPTION
Change `qstring.nest` to use `dict` in the returned nested object instead of `OrderedDict`. `dict` retains insertion order since Python 3.7, so `OrderedDict` usage was redundant here.