### PR TITLE
Migrate to .readthedocs.yaml configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  fail_on_warning: false

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,8 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../src"))
 from qstring import __version__
-
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Read the Docs will start requiring a `.readthedocs.yaml` configuration file for all projects in order to build documentation successfully. They plan to start failing builds not using a configuration file on September 25, 2023.