### PR TITLE
Fix `qstring.nest` to accept `Iterable` as `params`

### DIFF
--- a/src/qstring/nest.py
+++ b/src/qstring/nest.py
@@ -1,12 +1,12 @@
 import re
-from typing import Dict, Generator, List, Literal, NamedTuple, Tuple, Union
+from typing import Dict, Generator, Iterable, List, Literal, NamedTuple, Tuple, Union
 
 from . import exc
 
 Nested = Dict[str, Union[str, List[str], "Nested"]]
 
 
-def nest(params: List[Tuple[str, str]]) -> Nested:
+def nest(params: Iterable[Tuple[str, str]]) -> Nested:
     """
     Create a nested object from a list of query string parameters.
 
@@ -37,7 +37,7 @@ def nest(params: List[Tuple[str, str]]) -> Nested:
 
 
 def _convert_params_list_to_dict(
-    params_list: List[Tuple[str, str]]
+    params_list: Iterable[Tuple[str, str]]
 ) -> Dict[str, Union[str, List[str]]]:
     params_dict: Dict[str, Union[str, List[str]]] = {}
     for key, value in params_list:

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 
 import pytest
 
@@ -28,6 +28,14 @@ from qstring.nest import _merge
 )
 def test_nest(obj: List[Tuple[str, str]], expected: qstring.Nested) -> None:
     assert qstring.nest(obj) == expected
+
+
+def test_nest_accepts_iterable() -> None:
+    def items() -> Iterable[Tuple[str, str]]:
+        yield ("foo", "1")
+        yield ("foo", "2")
+
+    assert qstring.nest(items()) == {"foo": ["1", "2"]}
 
 
 def test_nest_maintains_order() -> None:


### PR DESCRIPTION
Fixed `qstring.nest` to use more relaxed `Iterable` type for `params` over `List`.